### PR TITLE
Fix playbook issues and add CI linting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build docker images
-        run: make build
+        run: docker compose build
 
       - name: Run format checks
-        run: make fmt_check
+        run: docker compose run --rm prettier npx prettier --check *.md **/*.yml
 
   lint:
     runs-on: macos-latest
@@ -26,13 +26,22 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install Ansible and ansible-lint
-        run: uv pip install --system ansible ansible-lint
+        run: |
+          uv venv .venv
+          source .venv/bin/activate
+          uv pip install ansible ansible-lint
 
       - name: Install Ansible Galaxy requirements
-        run: ansible-galaxy install -r requirements.yml
+        run: |
+          source .venv/bin/activate
+          ansible-galaxy install -r requirements.yml
 
       - name: Run ansible-lint
-        run: ansible-lint osx_defaults.yml
+        run: |
+          source .venv/bin/activate
+          ansible-lint osx_defaults.yml
 
       - name: Run syntax check
-        run: ansible-playbook osx_defaults.yml --syntax-check
+        run: |
+          source .venv/bin/activate
+          ansible-playbook osx_defaults.yml --syntax-check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Formatting checks
+name: CI
 
 on: [push]
 
@@ -6,16 +6,33 @@ env:
   TERM: xterm
 
 jobs:
-  test:
+  formatting:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v4
 
       - name: Build docker images
         run: make build
 
       - name: Run format checks
         run: make fmt_check
+
+  lint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install Ansible and ansible-lint
+        run: uv pip install --system ansible ansible-lint
+
+      - name: Install Ansible Galaxy requirements
+        run: ansible-galaxy install -r requirements.yml
+
+      - name: Run ansible-lint
+        run: ansible-lint osx_defaults.yml
+
+      - name: Run syntax check
+        run: ansible-playbook osx_defaults.yml --syntax-check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
 # Docker image target for linting the markdown files.
 #
-FROM node:fermium-alpine3.15 AS prettier
+FROM node:lts-alpine AS prettier
 RUN npm install --save-dev --save-exact prettier

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@
 # Docker image target for linting the markdown files.
 #
 FROM node:lts-alpine AS prettier
-RUN npm init -y && npm install --save-dev --save-exact prettier
+WORKDIR /app
+RUN npm cache clean --force && npm init -y && npm install --save-dev --save-exact prettier

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@
 # Docker image target for linting the markdown files.
 #
 FROM node:lts-alpine AS prettier
-RUN npm install --save-dev --save-exact prettier
+RUN npm init -y && npm install --save-dev --save-exact prettier

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ install: preinstall
 
 # Check and install prerequisites (Xcode CLI tools and Rosetta if needed)
 preinstall:
-	@if ! pkgutil --pkg-info=com.apple.pkg.CLTools_Executables >/dev/null 2>&1; then \
+	@if ! xcode-select -p >/dev/null 2>&1; then \
 		echo "Installing Xcode Command Line Tools..."; \
-		softwareupdate -i "Command Line Tools for Xcode-13.0"; \
+		xcode-select --install; \
 	fi
 	@if [ "$$(uname -m)" = "arm64" ]; then \
 		if ! pkgutil --pkg-info=com.apple.pkg.RosettaUpdateAuto >/dev/null 2>&1; then \
@@ -16,6 +16,10 @@ preinstall:
 			softwareupdate --install-rosetta; \
 		fi; \
 	fi
+
+lint:
+	uv run ansible-lint osx_defaults.yml
+	uv run ansible-playbook osx_defaults.yml --syntax-check
 
 fmt:
 	${DOCKER} prettier npx prettier --write *.md **/*.yml
@@ -25,4 +29,3 @@ fmt_check:
 
 build:
 	docker-compose build
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER = docker-compose run --rm
+DOCKER = docker compose run --rm
 
 install: preinstall
 	ansible-galaxy install -r requirements.yml
@@ -28,4 +28,4 @@ fmt_check:
 	${DOCKER} prettier npx prettier --check *.md **/*.yml
 
 build:
-	docker-compose build
+	docker compose build

--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ Provision and set up a new Mac computer using ansible.
 
 Run the commands:
 
-- ./bin/bootstrap
-- ./bin/apply
+```console
+make install
+```
 
-The first will install ansible on the system. Then the second will execute the ansible playbook. A specific commands can be run with `--tags`.
+This will install prerequisites (Xcode CLI tools, Rosetta on Apple Silicon), fetch Ansible dependencies, and run the playbook. Specific tasks can be run with `--tags`:
 
 ```console
-./bin/apply --tags osx
+uv run ansible-playbook osx_defaults.yml --tags osx --ask-become-pass
 ```
 
 ## Links

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,5 +2,4 @@
 nocows = True
 roles_path = ./roles:/etc/ansible/roles
 inventory = inventory
-become = true
 stdout_callback = yaml

--- a/default.config.yml
+++ b/default.config.yml
@@ -1,12 +1,6 @@
 ---
-downloads: "{{ ansible_env.HOME }}/.ansible-downloads"
-
-# Tell geerlingguy.mac.homebrew not to try installing Homebrew since it's already installed
-homebrew_install_if_missing: false
-
 homebrew_installed_packages:
   - aspell
-  - mactex
   - bat
   - cmake
   - coreutils
@@ -20,9 +14,7 @@ homebrew_installed_packages:
   - fish
   - fzf
   - gh
-  - ghostty
   - git-lfs
-  - hammerspoon
   - htop
   - java
   - jq
@@ -57,13 +49,13 @@ homebrew_cask_apps:
   - font-inconsolata-dz-for-powerline
   - font-raleway
   - freedom
+  - ghostty
+  - hammerspoon
+  - mactex
   - pycharm-ce
   - spotify
   - sublime-text
-homebrew_taps:
-  - homebrew/cask-fonts
-homebrew_cask_appdir: /Applications
-homebrew_upgrade_all_packages: true
+homebrew_taps: []
 
 configure_dock: true
 dockitems_remove:
@@ -91,4 +83,3 @@ dockitems_persist:
     path: "/Applications/Spotify.app/"
   - name: Ghostty
     path: "/Applications/Ghostty.app/"
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.9"
 services:
   prettier:
     build:

--- a/osx_defaults.yml
+++ b/osx_defaults.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Provision macOS development environment
+  hosts: localhost
   connection: local
   vars_files:
     - default.config.yml
@@ -9,8 +10,8 @@
   tasks:
     - name: Check for local modifications in dotfiles repository
       tags: ["dotfiles"]
-      ansible.builtin.shell:
-        cmd: git -C {{ ansible_env.HOME }}/.dotfiles diff --quiet || echo "has_changes"
+      ansible.builtin.command:
+        cmd: git -C {{ ansible_env.HOME }}/.dotfiles diff --quiet
       register: dotfiles_status
       changed_when: false
       failed_when: false
@@ -21,7 +22,7 @@
         repo: git@github.com:michaelbarton/dotfiles.git
         dest: "{{ ansible_env.HOME }}/.dotfiles"
         update: true
-      when: dotfiles_status.stdout is not defined or dotfiles_status.stdout != "has_changes"
+      when: dotfiles_status.rc is not defined or dotfiles_status.rc == 0
 
     - name: Ensure configured Homebrew taps are tapped
       tags: ["homebrew"]
@@ -59,11 +60,11 @@
 
     - name: Update macOS defaults
       tags: ["osx"]
-      include_tasks: tasks/osx_defaults.yml
+      ansible.builtin.include_tasks: tasks/osx_defaults.yml
 
     - name: Configure Dock
       tags: ["dock"]
-      include_role:
+      ansible.builtin.include_role:
         name: geerlingguy.mac.dock
 
     - name: Upgrade all Homebrew packages

--- a/osx_defaults.yml
+++ b/osx_defaults.yml
@@ -4,28 +4,27 @@
   vars_files:
     - default.config.yml
   vars:
-    # Skip Homebrew installation as it's already installed
     homebrew_install_if_missing: false
     homebrew_check_for_updates: true
   tasks:
     - name: Check for local modifications in dotfiles repository
-      tags: ['dotfiles']
-      shell: git -C {{ ansible_env.HOME }}/.dotfiles diff --quiet || echo "has_changes"
+      tags: ["dotfiles"]
+      ansible.builtin.shell:
+        cmd: git -C {{ ansible_env.HOME }}/.dotfiles diff --quiet || echo "has_changes"
       register: dotfiles_status
       changed_when: false
       failed_when: false
-      ignore_errors: true
 
     - name: Clone dotfiles repository
-      tags: ['dotfiles']
-      git:
+      tags: ["dotfiles"]
+      ansible.builtin.git:
         repo: git@github.com:michaelbarton/dotfiles.git
         dest: "{{ ansible_env.HOME }}/.dotfiles"
-        update: yes
+        update: true
       when: dotfiles_status.stdout is not defined or dotfiles_status.stdout != "has_changes"
 
     - name: Ensure configured Homebrew taps are tapped
-      tags: ['homebrew']
+      tags: ["homebrew"]
       community.general.homebrew_tap:
         name: "{{ item }}"
         state: present
@@ -33,58 +32,48 @@
       when: homebrew_taps | length > 0
 
     - name: Install Homebrew packages
-      tags: ['homebrew']
+      tags: ["homebrew"]
       community.general.homebrew:
         name: "{{ item }}"
         state: present
       loop: "{{ homebrew_installed_packages }}"
       when: homebrew_installed_packages | length > 0
-      register: brew_result
-      failed_when:
-        - brew_result is failed
-        - "'already installed' not in brew_result.msg|default('')"
 
     - name: Install Homebrew cask applications
-      tags: ['homebrew']
+      tags: ["homebrew"]
       community.general.homebrew_cask:
         name: "{{ item }}"
         state: present
       loop: "{{ homebrew_cask_apps }}"
       when: homebrew_cask_apps | length > 0
-      register: cask_result
-      failed_when:
-        - cask_result is failed
-        - "'Warning: Not upgrading' not in cask_result.msg|default('')"
-        - "'there is already an App' not in cask_result.msg|default('')"
 
     - name: Link homebrew dependencies
-      tags: ['homebrew']
-      file:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
+      tags: ["homebrew"]
+      become: true
+      ansible.builtin.file:
+        src: "{{ homebrew_prefix }}/opt/openjdk/libexec/openjdk.jdk"
+        dest: "/Library/Java/JavaVirtualMachines/openjdk.jdk"
         state: link
-      loop:
-        - { src: "/opt/homebrew/opt/openjdk/libexec/openjdk.jdk", dest: "/Library/Java/JavaVirtualMachines/openjdk.jdk" }
+      vars:
+        homebrew_prefix: "{{ '/opt/homebrew' if ansible_machine == 'arm64' else '/usr/local' }}"
 
-    - name: Update OSX defaults
-      tags: ['osx']
+    - name: Update macOS defaults
+      tags: ["osx"]
       include_tasks: tasks/osx_defaults.yml
 
     - name: Configure Dock
+      tags: ["dock"]
       include_role:
         name: geerlingguy.mac.dock
 
-    - name: Clean up Homebrew (remove outdated packages and casks)
-      tags: ['homebrew', 'cleanup']
+    - name: Upgrade all Homebrew packages
+      tags: ["homebrew", "cleanup"]
       community.general.homebrew:
         update_homebrew: true
         upgrade_all: true
-      register: cleanup_result
-      changed_when: cleanup_result.changed
 
-    - name: Run brew cleanup to remove outdated packages
-      tags: ['homebrew', 'cleanup']
+    - name: Remove outdated Homebrew package versions
+      tags: ["homebrew", "cleanup"]
       ansible.builtin.command: brew cleanup
       register: brew_cleanup
       changed_when: brew_cleanup.stdout != ""
-

--- a/osx_defaults.yml
+++ b/osx_defaults.yml
@@ -8,7 +8,7 @@
     homebrew_install_if_missing: false
     homebrew_check_for_updates: true
   tasks:
-    - name: Check for local modifications in dotfiles repository
+    - name: Check for local modifications in dotfiles repository # noqa: command-instead-of-module
       tags: ["dotfiles"]
       ansible.builtin.command:
         cmd: git -C {{ ansible_env.HOME }}/.dotfiles diff --quiet
@@ -16,7 +16,7 @@
       changed_when: false
       failed_when: false
 
-    - name: Clone dotfiles repository
+    - name: Clone dotfiles repository # noqa: latest[git]
       tags: ["dotfiles"]
       ansible.builtin.git:
         repo: git@github.com:michaelbarton/dotfiles.git


### PR DESCRIPTION
## Summary

- Move cask-only packages (ghostty, hammerspoon, mactex) from Homebrew formulae to casks and remove duplicates (sublime-text, pycharm-ce were in both lists)
- Remove deprecated `homebrew/cask-fonts` tap, unused variables, global `become: true`, fragile `failed_when` string matching, and redundant `ignore_errors`
- Add architecture-aware Homebrew prefix for Java symlink, use `xcode-select --install` instead of hardcoded Xcode version, add missing tags to Dock/OSX tasks, use FQCNs and `true` over `yes`
- Add `ansible-lint` and syntax-check CI job on a macOS runner, `make lint` target, and update README to reference `make install`

## Test plan

- [ ] Run `make lint` locally to verify ansible-lint and syntax check pass
- [ ] Run `make install` on a fresh or existing Mac to verify packages install correctly
- [ ] Verify CI passes on the macOS runner (ansible-lint + syntax-check)
- [ ] Confirm ghostty, hammerspoon, mactex install correctly as casks

https://claude.ai/code/session_011pPSSUAG9vC6z5iq76c9Kv